### PR TITLE
feat: Add automated PR testing workflow with uv

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,49 @@
+name: PR Tests
+
+on:
+  pull_request:
+    branches: [ main, master, develop ]
+    types: [ opened, synchronize, reopened ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      run: uv python install ${{ matrix.python-version }}
+    
+    - name: Install dependencies
+      run: uv sync --all-extras --dev
+    
+    - name: Lint with ruff
+      run: uv run ruff check .
+    
+    - name: Format check with ruff
+      run: uv run ruff format --check .
+    
+    - name: Type check with mypy
+      run: uv run mypy .
+    
+    - name: Run tests with pytest
+      run: uv run pytest --cov=anime_librarian --cov-report=term-missing --cov-report=xml
+    
+    - name: Upload coverage reports
+      uses: codecov/codecov-action@v4
+      if: matrix.python-version == '3.13'
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- Adds new GitHub Actions workflow for automated PR testing using `uv` package manager
- Tests across Python 3.11, 3.12, and 3.13 with coverage reporting
- Ensures consistency with project's specified package management tool

## Related Issue
Closes #16

## Changes Made
- Created `.github/workflows/pr-tests.yml` workflow that:
  - Triggers on PR open/synchronize/reopen events
  - Uses `uv` for dependency management (as specified in CLAUDE.md)
  - Runs ruff linting and formatting checks
  - Executes mypy type checking
  - Runs pytest with coverage reporting
  - Optionally uploads coverage to Codecov

## Test Plan
- [ ] Workflow triggers correctly on PR creation
- [ ] All quality checks pass (linting, formatting, type checking)
- [ ] Tests execute successfully across all Python versions
- [ ] Coverage reports are generated correctly

🤖 Generated with [Claude Code](https://claude.ai/code)