### PR TITLE
fix: improve confirmation prompt format to standard [Y/n] notation

### DIFF
--- a/src/anime_librarian/rich_output_writer.py
+++ b/src/anime_librarian/rich_output_writer.py
@@ -256,7 +256,16 @@ class RichInputReader:
         Returns:
             True if confirmed, False otherwise
         """
-        return Confirm.ask(prompt, default=default, console=self.console.console)
+        # Format prompt with standard [Y/n] or [y/N] notation
+        choices = "[Y/n]" if default else "[y/N]"
+        formatted_prompt = f"{prompt} {choices}"
+        return Confirm.ask(
+            formatted_prompt,
+            default=default,
+            console=self.console.console,
+            show_choices=False,
+            show_default=False,
+        )
 
     def read_input(self, prompt: str) -> str:
         """


### PR DESCRIPTION
## Description

Improves the confirmation prompt format to follow standard CLI conventions by removing redundant default indicators and using uppercase letters to show the default choice.

Fixes #37

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Modified `RichInputReader.confirm()` method to format prompts with standard `[Y/n]` or `[y/N]` notation
- Disabled Rich's automatic `show_choices` and `show_default` to prevent redundant indicators
- Uppercase letter now clearly indicates the default choice

## Before & After

**Before:**
```
Continue with the file moves? [y/n] (y):
```

**After:**
```
Continue with the file moves? [Y/n]:
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Code Quality Checks

- [x] Linting with ruff passes
- [x] Formatting with ruff passes
- [x] Type checking passes
- [x] Unit tests with pytest pass (19 passed)

🤖 Generated with [Claude Code](https://claude.ai/code)